### PR TITLE
Fixes

### DIFF
--- a/defog_utils/utils_db.py
+++ b/defog_utils/utils_db.py
@@ -18,14 +18,23 @@ creds_local_pg = {
 }
 
 reserved_keywords = [
+    "abs",
     "all",
     "and",
     "any",
+    "avg",
     "as",
+    "at",
     "asc",
+    "bit",
+    "by",
+    "day",
+    "dec",
     "do",
+    "div",
     "end",
     "for",
+    "go",
     "in",
     "is",
     "not",
@@ -456,8 +465,10 @@ def generate_aliases(
     for original_table_name in table_names:
         if "." in original_table_name:
             table_name = original_table_name.rsplit(".", 1)[-1]
+            print(f"split: {original_table_name.rsplit('.', 1)}")
         else:
             table_name = original_table_name
+            print(f"original: {table_name}")
         if "_" in table_name:
             # get the first letter of each subword delimited by "_"
             alias = "".join([word[0] for word in table_name.split("_")]).lower()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     description="Various helper functions used by Defog projects",
     author="defog",
     author_email="support@defog.ai",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     install_requires=[
         "numpy",
         "sqlglot",


### PR DESCRIPTION
Added more keywords that we should exclude when generating table aliases.
Exclude tests directory from package installation.

The reason for adding `go` is because of this weird `sqlparse.format` error as well:
```py
sql = "SELECT game_id FROM game_outcomes go WHERE go.duration > 120;"
sqlparse.format(sql, keyword_case="upper", strip_whitespace=True, strip_comments=True)
# 'SELECT game_id FROM game_outcomes GOWHERE go.duration > 120;'
```