### PR TITLE
Quotes in col name

### DIFF
--- a/defog_utils/utils_db.py
+++ b/defog_utils/utils_db.py
@@ -137,7 +137,7 @@ def mk_create_table_ddl(table_name: str, columns: List[Dict[str, str]]) -> str:
     for i, column in enumerate(columns):
         col_name = column["column_name"]
         # if column name has spaces, wrap it in double quotes
-        if " " in col_name:
+        if " " in col_name and '"' not in col_name:
             col_name = f'"{col_name}"'
         dtype = convert_data_type_postgres(column["data_type"])
         col_desc = column.get("column_description", "").replace("\n", " ")


### PR DESCRIPTION
Just found a teeny bug that added extra double quotes when column name with spaces already is encased in quotes