### PR TITLE
Fix bug

### DIFF
--- a/tests/test_utils_sql.py
+++ b/tests/test_utils_sql.py
@@ -954,6 +954,13 @@ RIGHT JOIN unique_games ug ON pg.game_id = ug.gm_game_id;"""
         print(result)
         self.assertEqual(result, expected)
 
+    def test_sql_3(self):
+        sql = "SELECT CAST((SELECT COUNT(aw.artwork_id) FROM artwork aw WHERE aw.year_created = 1888 AND aw.description IS NULL) AS FLOAT) / NULLIF((SELECT COUNT(at.artist_id) FROM artists AT WHERE at.nationality ilike '%French%'), 0) AS ratio;"
+        new_alias_map = {'exhibit_artworks': 'ea', 'exhibitions': 'e', 'collaborations': 'c', 'artwork': 'a', 'artists': 'ar'}
+        expected = "SELECT CAST((SELECT COUNT(a.artwork_id) FROM artwork AS a WHERE a.year_created = 1888 AND a.description IS NULL) AS DOUBLE PRECISION) / NULLIF((SELECT COUNT(ar.artist_id) FROM artists AS ar WHERE ar.nationality ILIKE '%French%'), 0) AS ratio"
+        result = replace_alias(sql, new_alias_map)
+        print(result)
+        self.assertEqual(result, expected)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix bug in `replace_alias` due to case mismatch. Previously, if we had this sql
```sql
SELECT at.id FROM artist AT
```
and had `new_alias_map = {"artist": "ar"}`
This would fail to swap out the `at` as `AT` would be in the `existing_alias_map` and looking `at` up in `existing_alias_map` would fail, and therefore not get replaced.

Also added `test_valid_md_sql` to test md and sql in a single function call. This is to avoid having to create and tear down the db twice while testing the md and sql separately. We also leave the db creation/tear-down outside of this function to allow it to be managed separately (eg by the calling process, so that we don't have to keep creating/tearing down databases for each example, but can just do so at the start and end of each calling process).