### PR TITLE
Refine mk_delete_ddl

### DIFF
--- a/defog_utils/utils_db.py
+++ b/defog_utils/utils_db.py
@@ -1,6 +1,6 @@
 # File for all db-related operations confined to psycopg2/sqlalchemy
 import re
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import psycopg2
 
@@ -223,15 +223,19 @@ def mk_create_ddl(md: Dict[str, List[Dict[str, str]]]) -> str:
     return md_create
 
 
-def mk_delete_ddl(
-    md: Dict[str, List[Dict[str, str]]], schema_in_table_name: bool = False
-) -> str:
+def mk_delete_ddl(md: Dict[str, Any]) -> str:
     """
     Return a DDL statement for deleting tables from a metadata dictionary
     `md` has the same structure as in `mk_create_ddl`
     This is for purging our temporary tables after creating them and testing the sql query
     """
-    if schema_in_table_name:
+    is_schema = False
+    for _, contents in md.items():
+        # check if the contents is a dictionary of tables or a list of tables
+        is_schema = isinstance(contents, Dict)
+        break
+        
+    if is_schema:
         md_delete = ""
         for schema, tables in md.items():
             schema = normalize_table_name(schema)

--- a/tests/test_utils_db.py
+++ b/tests/test_utils_db.py
@@ -180,7 +180,41 @@ class TestMkCreateDDLWithSchema(unittest.TestCase):
 
 
 class TestMkDeleteDDLWithSchema(unittest.TestCase):
-    def test_mk_delete_ddl(self):
+    def test_mk_delete_ddl_tables(self):
+        md = {
+            "table1": [
+                {
+                    "column_name": "col1",
+                    "data_type": "int",
+                    "column_description": "primary key",
+                },
+                {
+                    "column_name": "col2",
+                    "data_type": "text",
+                    "column_description": "not null",
+                },
+                {"column_name": "col3", "data_type": "text", "column_description": ""},
+            ],
+            "table2": [
+                {
+                    "column_name": "col1",
+                    "data_type": "int",
+                    "column_description": "primary key",
+                },
+                {
+                    "column_name": "col2",
+                    "data_type": "text",
+                    "column_description": "not null",
+                },
+            ],
+        }
+        expected_output = (
+            "DROP TABLE IF EXISTS table1 CASCADE;\n"
+            "DROP TABLE IF EXISTS table2 CASCADE;\n"
+        )
+        self.assertEqual(mk_delete_ddl(md), expected_output)
+
+    def test_mk_delete_ddl_schema(self):
         md = {
             "schema1": {
                 "table1": [
@@ -215,7 +249,7 @@ class TestMkDeleteDDLWithSchema(unittest.TestCase):
             }
         }
         expected_output = "DROP SCHEMA IF EXISTS schema1 CASCADE;\n"
-        self.assertEqual(mk_delete_ddl(md, True), expected_output)
+        self.assertEqual(mk_delete_ddl(md), expected_output)
 
 
 class TestFixMd(unittest.TestCase):


### PR DESCRIPTION
Refine `mk_delete_ddl` to automatically detect if a schema is structure is present and return the right drop statements. This saves us a little parsing since the information is implicit in the first argument (`md`).