### PR TITLE
fix trailing comma in parse_md

### DIFF
--- a/defog_utils/utils_db.py
+++ b/defog_utils/utils_db.py
@@ -486,8 +486,9 @@ def parse_md(md_str: str) -> Dict[str, List[Dict[str, str]]]:
             # split the column_str into the column name/type and the description
             column_str_split = re.split(r",?\s*--", column_str, 1)
             if len(column_str_split) == 1:
-                # if no -- is found, then there is no description
-                column_name_type = column_str.split(",", 1)[0]
+                # if no -- is found, then there is no description and we will
+                # just remove the trailing comma and optional spaces if it exists
+                column_name_type = re.sub(r",?\s*$", "", column_str_split[0])
                 column_desc = ""
             else:
                 # if -- is found, then the second part is the description

--- a/tests/test_utils_db.py
+++ b/tests/test_utils_db.py
@@ -338,7 +338,7 @@ class TestFixMd(unittest.TestCase):
 
 
 class TestParseMd(unittest.TestCase):
-    def test_parse_md(self):
+    def test_parse_md_1(self):
         md_str = (
             "CREATE TABLE schema1.table1 (\n"
             "  my col1 integer, --primary key\n"
@@ -380,6 +380,41 @@ class TestParseMd(unittest.TestCase):
             ],
         }
         self.assertEqual(parse_md(md_str), expected_output)
+
+    def test_parse_md_2(self):
+        md_str = """CREATE TABLE acct_trx (
+  trx_units numeric(10,2),
+  asset_id integer,
+  trx_amount numeric(10,2),
+  details varchar(500),
+  id integer, --Primary key for acct_trx table, joinable with other tables
+  settle_date date, --Date transaction settled
+  symbol varchar(10)
+);
+CREATE TABLE acct_perf (
+  ytd_return numeric(5,2),
+  acct_snapshot_date text, --format: yyyy-mm-dd
+  account_id integer --Primary key, foreign key to cust_acct table
+);"""
+        expected = {
+            "acct_trx": [
+                {"column_name": "trx_units", "data_type": "numeric(10,2)", "column_description": ""},
+                {"column_name": "asset_id", "data_type": "integer", "column_description": ""},
+                {"column_name": "trx_amount", "data_type": "numeric(10,2)", "column_description": ""},
+                {"column_name": "details", "data_type": "varchar(500)", "column_description": ""},
+                {"column_name": "id", "data_type": "integer", "column_description": "Primary key for acct_trx table, joinable with other tables"},
+                {"column_name": "settle_date", "data_type": "date", "column_description": "Date transaction settled"},
+                {"column_name": "symbol", "data_type": "varchar(10)", "column_description": ""},
+            ],
+            "acct_perf": [
+                {"column_name": "ytd_return", "data_type": "numeric(5,2)", "column_description": ""},
+                {"column_name": "acct_snapshot_date", "data_type": "text", "column_description": "format: yyyy-mm-dd"},
+                {"column_name": "account_id", "data_type": "integer", "column_description": "Primary key, foreign key to cust_acct table"},
+            ],
+        }
+        md = parse_md(md_str)
+        print(md)
+        self.assertDictEqual(md, expected)
 
 
 class TestGetTableNames(unittest.TestCase):

--- a/tests/test_utils_sql.py
+++ b/tests/test_utils_sql.py
@@ -6,7 +6,6 @@ from defog_utils.defog_utils.utils_sql import (
     get_sql_features,
     is_date_or_time_str,
     is_sorry_sql,
-    normalize_sql,
     replace_alias,
     shuffle_table_metadata,
 )


### PR DESCRIPTION
Similar to #9 , we also need to fix the parsing of the metadata by only stripping the trailing commas and not just naively splitting on `,`.
Added test case to check that we don't butcher `numeric(10,2)` into 2.

fixing this bumped up the valid realiased sql for `train_data/validity_results/train_4/extra_basic_joins_realias.json` from this:
```
Valid old metadata: 2640/2812
Valid old SQL: 2640/2812
Valid shuffled metadata: 2640/2812
Valid realiased SQL: 2635/2812
```
to this now:
```
Valid old metadata: 2812/2812
Valid old SQL: 2812/2812
Valid shuffled metadata: 2812/2812
Valid realiased SQL: 2808/2812
```
which is a 100% validity for shuffled metadata and only 4 faulty queries out of 2812 😄 