### PR TITLE
Schema condition in parse_md

### DIFF
--- a/defog_utils/utils_db.py
+++ b/defog_utils/utils_db.py
@@ -474,7 +474,7 @@ def parse_md(md_str: str) -> Dict[str, List[Dict[str, str]]]:
         # split the table_md_str into the header and the columns
         header, columns_str = table_md_str.split("(", 1)
         table_name = header.split("CREATE TABLE", 1)[1].strip()
-        if "." in table_name:
+        if "." in table_name and not table_name.startswith('"'):
             schema, table_name = table_name.split(".", 1)
         else:
             schema = None


### PR DESCRIPTION
Only consider table_name to have schema if it has period AND the table_name is not enclosed by quotes.
e.g. `machine.type` has schema `machine` whereas `"machine.type"` has no schema and is considered a table name.
This is especially for cases in `train_4_newcolnames.json` in datagen.