### PR TITLE
Backticks in schema

### DIFF
--- a/defog_utils/utils_sql.py
+++ b/defog_utils/utils_sql.py
@@ -150,6 +150,7 @@ def get_schema_features(schema_raw: str) -> Tuple[SchemaFeatures, Dict[str, str]
     features = SchemaFeatures()
     # preprocess the schema to avoid a few edge cases. these are inconsequential
     # for the purposes of feature extraction
+    schema_raw = re.sub("`", "", schema_raw)
     schema_raw = re.sub("```", "", schema_raw)
     split_ddl = schema_raw.split("Here is a list of joinable columns", 1)
     if len(split_ddl) >= 2 and split_ddl[1].strip():


### PR DESCRIPTION
Small change: Remove single backticks around column names in schema as sqlglot cannot parse them