### PR TITLE
fix alias with multiple internal underscores

### DIFF
--- a/defog_utils/utils_db.py
+++ b/defog_utils/utils_db.py
@@ -577,7 +577,9 @@ def generate_aliases_dict(
         if "_" in table_name:
             # get the first letter of each subword delimited by "_"
             table_name = table_name.strip("_")
-            alias = "".join([word[0] for word in table_name.split("_")]).lower()
+            # use re to split on one or more underscores
+            words = re.split(r"_+", table_name)
+            alias = "".join(word[0] for word in words).lower()
         else:
             # if camelCase, get the first letter of each subword
             # otherwise defaults to just getting the 1st letter of the table_name

--- a/tests/test_utils_db.py
+++ b/tests/test_utils_db.py
@@ -624,10 +624,10 @@ class TestGenerateAliases(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     def test_generate_aliases_with_dots_and_underscores(self):
-        table_names = ["db.schema.table1", "db.schema.table2", "db.schema.table3", "_uncompressed"]
+        table_names = ["db.schema.table1", "db.schema.table2", "db.schema.table3", "_uncompressed___long_name_"]
         result = generate_aliases(table_names)
         print(result)
-        expected_result = "-- db.schema.table1 AS t1\n-- db.schema.table2 AS t2\n-- db.schema.table3 AS t3\n-- _uncompressed AS u\n"
+        expected_result = "-- db.schema.table1 AS t1\n-- db.schema.table2 AS t2\n-- db.schema.table3 AS t3\n-- _uncompressed___long_name_ AS uln\n"
         self.assertEqual(result, expected_result)
 
 


### PR DESCRIPTION
Previous fix dealt with leading and trailing underscores but the test would still fail with multiple internal underscores since we're splitting on individual underscores. The updated fix splits on 1 or more consecutive underscores.