### PR TITLE
Add gemini

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,4 +23,5 @@ jobs:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
+        GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 

--- a/defog_utils/utils_multi_llm.py
+++ b/defog_utils/utils_multi_llm.py
@@ -1,0 +1,28 @@
+import concurrent
+from typing import Callable, Dict
+
+from .utils_llm import LLMResponse, chat_anthropic, chat_gemini, chat_openai, chat_together
+
+def map_model_to_chat_fn(model: str) -> Callable:
+    """
+    Returns the appropriate chat function based on the model.
+    """
+    if model.startswith("claude"):
+        return chat_anthropic
+    if model.startswith("gemini"):
+        return chat_gemini
+    if model.startswith("gpt"):
+        return chat_openai
+    if model.startswith("meta-llama") or model.startswith("mistralai") or model.startswith("Qwen"):
+        return chat_together
+    raise ValueError(f"Unknown model: {model}")
+
+def chat(models, messages, max_tokens=8192, temperature=0.0, stop=[], json_mode=False, seed=0) -> Dict[str, LLMResponse]:
+    """
+    Returns the response from the LLM API for each of the models passed in.
+    Output format is a dictionary keyed by model name.
+    """
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(models)) as executor:
+        futures = {executor.submit(map_model_to_chat_fn(model), messages, model, max_tokens, temperature, stop, json_mode, seed): model for model in models}
+        responses = {futures[future]: future.result() for future in concurrent.futures.as_completed(futures)}
+    return responses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 anthropic==0.37.1
+google-generativeai==0.8.3
 numpy
 openai==1.52.2
 psycopg2-binary==2.9.9

--- a/tests/test_utils_llm.py
+++ b/tests/test_utils_llm.py
@@ -3,11 +3,13 @@ import unittest
 from ..defog_utils.utils_llm import (
     LLMResponse,
     chat_anthropic,
+    chat_gemini,
     chat_openai,
     chat_together,
 )
 
-messages = [
+messages_no_sys = [{"role": "user", "content": "Return a greeting in not more than 2 words\n"}]
+messages_sql = [
     {
         "role": "system",
         "content": "Your task is to generate SQL given a natural language question and schema of the user's database. Do not use aliases. Return only the SQL without ```.",
@@ -50,24 +52,72 @@ CREATE TABLE orders (
 ]
 
 acceptable_sql = [
-    "SELECT COUNT(*) FROM orders",
-    "SELECT COUNT(order_id) FROM orders",
+    "select count(*) from orders",
+    "select count(order_id) from orders",
+    "select count(*) as total_orders from orders",
+    "select count(order_id) as total_orders from orders",
 ]
 
-acceptable_sql_from_json = set(
-    [
-        "SELECT COUNT(order_id) as total_orders FROM orders;",
-        "SELECT COUNT(*) AS total_orders FROM orders;",
-        "SELECT COUNT(order_id) FROM orders;",
-        "SELECT COUNT(*) FROM orders;",
-    ]
-)
-
-
 class TestChatClients(unittest.TestCase):
-    def test_chat_anthropic(self):
+
+    def check_sql(self, sql: str):
+        self.assertIn(sql.strip(";\n").lower(), acceptable_sql)
+
+    def test_chat_anthropic_no_sys(self):
         response = chat_anthropic(
-            messages,
+            messages_no_sys,
+            model="claude-3-haiku-20240307",
+            max_tokens=10,
+            seed=0,
+        )
+        print(response)
+        self.assertIsInstance(response, LLMResponse)
+        self.assertIsInstance(response.content, str)
+        self.assertEqual(response.input_tokens, 18)
+        self.assertLessEqual(response.output_tokens, 10)
+
+    def test_chat_gemini_no_sys(self):
+        response = chat_gemini(
+            messages_no_sys,
+            model="gemini-1.5-flash",
+            max_tokens=10,
+            seed=0,
+        )
+        print(response)
+        self.assertIsInstance(response, LLMResponse)
+        self.assertIsInstance(response.content, str)
+        self.assertEqual(response.input_tokens, 12)
+        self.assertLessEqual(response.output_tokens, 10)
+
+    def test_chat_openai_no_sys(self):
+        response = chat_openai(
+            messages_no_sys,
+            model="gpt-4o-mini",
+            max_tokens=10,
+            seed=0,
+        )
+        print(response)
+        self.assertIsInstance(response, LLMResponse)
+        self.assertIsInstance(response.content, str)
+        self.assertEqual(response.input_tokens, 18)
+        self.assertLessEqual(response.output_tokens, 10)
+
+    def test_chat_together_no_sys(self):
+        response = chat_together(
+            messages_no_sys,
+            model="meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+            max_tokens=10,
+            seed=0,
+        )
+        print(response)
+        self.assertIsInstance(response, LLMResponse)
+        self.assertIsInstance(response.content, str)
+        self.assertEqual(response.input_tokens, 46) # hidden sys prompt added I think
+        self.assertLessEqual(response.output_tokens, 10)
+
+    def test_chat_anthropic_sql(self):
+        response = chat_anthropic(
+            messages_sql,
             model="claude-3-haiku-20240307",
             max_tokens=100,
             stop=[";"],
@@ -75,30 +125,38 @@ class TestChatClients(unittest.TestCase):
         )
         print(response)
         self.assertIsInstance(response, LLMResponse)
-        self.assertIn(response.content, acceptable_sql)
+        self.check_sql(response.content)
         self.assertEqual(response.input_tokens, 90)  # 90 input tokens
-        self.assertTrue(response.output_tokens < 10)  # output tokens should be < 10
+        self.assertTrue(response.output_tokens < 15)  # output tokens should be < 15
 
-    def test_chat_openai(self):
-        response = chat_openai(messages, model="gpt-4o-mini", stop=[";"], seed=0)
+    def test_chat_openai_sql(self):
+        response = chat_openai(messages_sql, model="gpt-4o-mini", stop=[";"], seed=0)
         print(response)
         self.assertIsInstance(response, LLMResponse)
-        self.assertIn(response.content, acceptable_sql)
+        self.check_sql(response.content)
         self.assertEqual(response.input_tokens, 83)
         self.assertTrue(response.output_tokens < 10)  # output tokens should be < 10
 
-    def test_chat_together(self):
+    def test_chat_together_sql(self):
         response = chat_together(
-            messages,
+            messages_sql,
             model="meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
             stop=[";"],
             seed=0,
         )
         print(response)
         self.assertIsInstance(response, LLMResponse)
-        self.assertIn(response.content, acceptable_sql)
+        self.check_sql(response.content)
         self.assertEqual(response.input_tokens, 108)
         self.assertTrue(response.output_tokens < 10)  # output tokens should be < 10
+
+    def test_chat_gemini_sql(self):
+        response = chat_gemini(messages_sql, model="gemini-1.5-flash", stop=[";"], seed=0)
+        print(response)
+        self.assertIsInstance(response, LLMResponse)
+        self.check_sql(response.content)
+        self.assertEqual(response.input_tokens, 86)
+        self.assertTrue(response.output_tokens < 10)
 
     def test_chat_json_anthropic(self):
         response = chat_anthropic(
@@ -111,7 +169,7 @@ class TestChatClients(unittest.TestCase):
         print(response)
         self.assertIsInstance(response, LLMResponse)
         resp_dict = json.loads(response.content)
-        self.assertIn(resp_dict["sql"], acceptable_sql_from_json)
+        self.check_sql(resp_dict["sql"])
         self.assertIsInstance(resp_dict["reasoning"], str)
         self.assertIsInstance(response.input_tokens, int)
         self.assertIsInstance(response.output_tokens, int)
@@ -123,7 +181,7 @@ class TestChatClients(unittest.TestCase):
         print(response)
         self.assertIsInstance(response, LLMResponse)
         resp_dict = json.loads(response.content)
-        self.assertIn(resp_dict["sql"], acceptable_sql_from_json)
+        self.check_sql(resp_dict["sql"])
         self.assertIsInstance(resp_dict["reasoning"], str)
         self.assertIsInstance(response.input_tokens, int)
         self.assertIsInstance(response.output_tokens, int)
@@ -139,7 +197,19 @@ class TestChatClients(unittest.TestCase):
         self.assertIsInstance(response, LLMResponse)
         raw_output = response.content
         resp_dict = json.loads(raw_output)
-        self.assertIn(resp_dict["sql"], acceptable_sql_from_json)
+        self.check_sql(resp_dict["sql"])
+        self.assertIsInstance(resp_dict["reasoning"], str)
+        self.assertIsInstance(response.input_tokens, int)
+        self.assertIsInstance(response.output_tokens, int)
+
+    def test_chat_json_gemini(self):
+        response = chat_gemini(
+            messages_json, model="gemini-1.5-flash", seed=0, json_mode=True
+        )
+        print(response)
+        self.assertIsInstance(response, LLMResponse)
+        resp_dict = json.loads(response.content)
+        self.check_sql(resp_dict["sql"])
         self.assertIsInstance(resp_dict["reasoning"], str)
         self.assertIsInstance(response.input_tokens, int)
         self.assertIsInstance(response.output_tokens, int)

--- a/tests/test_utils_multi_llm.py
+++ b/tests/test_utils_multi_llm.py
@@ -1,0 +1,77 @@
+import unittest
+from ..defog_utils.utils_multi_llm import map_model_to_chat_fn, chat
+from ..defog_utils.utils_llm import LLMResponse, chat_anthropic, chat_gemini, chat_openai, chat_together
+
+messages_sql = [
+    {
+        "role": "system",
+        "content": "Your task is to generate SQL given a natural language question and schema of the user's database. Do not use aliases. Return only the SQL without ```.",
+    },
+    {
+        "role": "user",
+        "content": f"""Question: What is the total number of orders?
+Schema:
+```sql
+CREATE TABLE orders (
+    order_id int,
+    customer_id int,
+    employee_id int,
+    order_date date
+);
+```
+""",
+    },
+]
+
+acceptable_sql = [
+    "select count(*) from orders",
+    "select count(order_id) from orders",
+    "select count(*) as total_orders from orders",
+    "select count(order_id) as total_orders from orders",
+]
+
+class TestChatClients(unittest.TestCase):
+    def check_sql(self, sql: str):
+        self.assertIn(sql.strip(";\n").lower(), acceptable_sql)
+
+    def test_map_model_to_chat_fn(self):
+        self.assertEqual(map_model_to_chat_fn("claude-3-5-sonnet-20241022"), chat_anthropic)
+        self.assertEqual(map_model_to_chat_fn("gemini-1.5-pro"), chat_gemini)
+        self.assertEqual(map_model_to_chat_fn("gpt-4o"), chat_openai)
+        self.assertEqual(map_model_to_chat_fn("mistralai/Mistral-7B-Instruct-v0.3"), chat_together)
+        self.assertEqual(map_model_to_chat_fn("meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo"), chat_together)
+        self.assertEqual(map_model_to_chat_fn("Qwen/Qwen2.5-72B-Instruct-Turbo"), chat_together)
+        with self.assertRaises(ValueError):
+            map_model_to_chat_fn("unknown-model")
+
+    def test_simple_chat(self):
+        models = ["claude-3-haiku-20240307", "gemini-1.5-flash-002", "gpt-4o-mini", "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo"]
+        messages = [{"role": "user", "content": "Return a greeting in not more than 2 words\n"}]
+        responses = chat(models, messages, max_tokens=20, temperature=0.0, stop=[";"], json_mode=False, seed=0)
+        self.assertIsInstance(responses, dict)
+        for model in models:
+            self.assertIn(model, responses)
+            response = responses[model]
+            print(model, response)
+            self.assertIsInstance(response, LLMResponse)
+            self.assertIsInstance(response.content, str)
+            self.assertIsInstance(response.time, float)
+            self.assertLess(response.input_tokens, 50) # higher as default system prompt is added in together's API when none provided
+            self.assertLess(response.output_tokens, 20)
+
+    def test_sql_chat(self):
+        models = ["claude-3-haiku-20240307", "gemini-1.5-flash-002", "gpt-4o-mini", "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo"]
+        responses = chat(models, messages_sql, max_tokens=20, temperature=0.0, stop=[";"], json_mode=False, seed=0)
+        self.assertIsInstance(responses, dict)
+        for model in models:
+            self.assertIn(model, responses)
+            response = responses[model]
+            print(model, response)
+            self.assertIsInstance(response, LLMResponse)
+            self.assertIsInstance(response.content, str)
+            self.assertIsInstance(response.time, float)
+            self.assertLess(response.input_tokens, 110)
+            self.assertLess(response.output_tokens, 20)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Changes
- Add gemini client. Some caveats:
  - Google's client has a weird thing where not only the system instructions are passed in separately during the `GenerativeModel`, but the latest message and the history (excluding the latest message) are passed separately. The history goes into `start_chat` while the latest message goes into `send_message`, which is really weird imho.
  - Unfortunately the seed parameter is not supported in the latest version: https://github.com/google-gemini/generative-ai-python/issues/605, so we just made a short note.
- Add multi-llm querying in parallel. This is mostly for agents-style workloads.

Added tests for the gemini client and multi-llm querying. Have also added `GEMINI_API_KEY` into our organization secrets to facilitate CI testing.