### PR TITLE
Implement exponential backoff for chat_async function

### DIFF
--- a/defog_utils/utils_multi_llm.py
+++ b/defog_utils/utils_multi_llm.py
@@ -1,6 +1,6 @@
 import concurrent
 import asyncio
-from typing import Callable, Dict, List, Dict, Any, Optional, Union
+from typing import Callable, Dict
 
 from .utils_llm import (
     LLMResponse,


### PR DESCRIPTION
LLMs calls can sometimes fail unexpectedly. To handle these scenarios, we implementation a retry with exponential backoff in the `chat_async` function.

Verifying that an endpoint that uses `chat_async` still works

```python
curl -X 'POST' \
  'http://localhost:1234/generate_query_chat' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "api_key": "fbc046431bd131d1c6c55c782d8bbd413a339d9c78ec6da6fea73cdfaeacb897",
  "db_type": "postgres",
  "previous_context": [],
  "question": "how many activations in 2024?"
}'
```

Runs successfully