### PR TITLE
Add support for DeepSeek models in `chat_async`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,4 +24,5 @@ jobs:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
 

--- a/defog_utils/utils_llm.py
+++ b/defog_utils/utils_llm.py
@@ -164,6 +164,8 @@ def chat_openai(
     stop: List[str] = [],
     response_format=None,
     seed: int = 0,
+    base_url: str = "https://api.openai.com/v1/",
+    api_key: str = os.environ.get("OPENAI_API_KEY", ""),
 ) -> LLMResponse:
     """
     Returns the response from the OpenAI API, the time taken to generate the response, the number of input tokens used, and the number of output tokens used.
@@ -171,7 +173,10 @@ def chat_openai(
     """
     from openai import OpenAI
 
-    client_openai = OpenAI()
+    client_openai = OpenAI(
+        base_url=base_url,
+        api_key=api_key
+    )
     t = time.time()
     if model in ["o1-mini", "o1-preview"]:
         if messages[0].get("role") == "system":
@@ -235,6 +240,8 @@ async def chat_openai_async(
     store=True,
     metadata=None,
     timeout=100,
+    base_url: str = "https://api.openai.com/v1/",
+    api_key: str = os.environ.get("OPENAI_API_KEY", ""),
 ) -> LLMResponse:
     """
     Returns the response from the OpenAI API, the time taken to generate the response, the number of input tokens used, and the number of output tokens used.
@@ -242,10 +249,13 @@ async def chat_openai_async(
     """
     from openai import AsyncOpenAI
 
-    client_openai = AsyncOpenAI()
+    client_openai = AsyncOpenAI(
+        base_url=base_url,
+        api_key=api_key
+    )
     t = time.time()
     
-    if model in ["o1-mini", "o1-preview", "o1"]:
+    if model in ["o1-mini", "o1-preview", "o1", "deepseek-chat", "deepseek-reasoner"]:
         # remove system prompt
         if messages[0].get("role") == "system":
             sys_msg = messages[0]["content"]
@@ -265,10 +275,10 @@ async def chat_openai_async(
         "response_format": response_format,
     }
     
-    if model in ["o1-mini", "o1-preview", "o1"]:
+    if model in ["o1-mini", "o1-preview", "o1", "deepseek-chat", "deepseek-reasoner"]:
         del request_params["temperature"]
     
-    if model in ["o1-mini", "o1-preview"]:
+    if model in ["o1-mini", "o1-preview", "deepseek-chat", "deepseek-reasoner"]:
         del request_params["response_format"]
     
     if "response_format" in request_params and request_params["response_format"]:

--- a/defog_utils/utils_multi_llm.py
+++ b/defog_utils/utils_multi_llm.py
@@ -1,6 +1,7 @@
 import concurrent
 import asyncio
 from typing import Callable, Dict
+import os
 
 from .utils_llm import (
     LLMResponse,

--- a/tests/test_utils_multi_llm.py
+++ b/tests/test_utils_multi_llm.py
@@ -237,8 +237,6 @@ class TestChatClients(unittest.IsolatedAsyncioTestCase):
             "gpt-4o",
             "o1",
             "gemini-2.0-flash-exp",
-            "deepseek-chat",
-            "deepseek-reasoner"
         ]
         for model in models:
             response = await chat_async(

--- a/tests/test_utils_multi_llm.py
+++ b/tests/test_utils_multi_llm.py
@@ -186,7 +186,9 @@ class TestChatClients(unittest.IsolatedAsyncioTestCase):
             "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
             # "o1-mini", --o1-mini seems to be having issues, and o3-mini will be out soon anyway. so leaving out for now
             "o1",
-            "gemini-2.0-flash-exp"
+            "gemini-2.0-flash-exp",
+            "deepseek-chat",
+            "deepseek-reasoner"
         ]
         messages = [
             {"role": "user", "content": "Return a greeting in not more than 2 words\n"}
@@ -212,7 +214,9 @@ class TestChatClients(unittest.IsolatedAsyncioTestCase):
             "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
             # "o1-mini", --o1-mini seems to be having issues, and o3-mini will be out soon anyway. so leaving out for now
             "o1",
-            "gemini-2.0-flash-exp"
+            "gemini-2.0-flash-exp",
+            "deepseek-chat",
+            "deepseek-reasoner"
         ]
         for model in models:
             response = await chat_async(
@@ -233,6 +237,8 @@ class TestChatClients(unittest.IsolatedAsyncioTestCase):
             "gpt-4o",
             "o1",
             "gemini-2.0-flash-exp",
+            "deepseek-chat",
+            "deepseek-reasoner"
         ]
         for model in models:
             response = await chat_async(


### PR DESCRIPTION
This adds support for deepseek models by modifying the `chat_openai` and `chat_openai_async` functions to take in optional `base_url` and `api_key` parameters.

Also adds tests for the deepseek models, which are integrated with Github CI.