### PR TITLE
Clean up system message handling in openai

### DIFF
--- a/defog_utils/utils_llm.py
+++ b/defog_utils/utils_llm.py
@@ -266,11 +266,20 @@ async def chat_openai_async(
     t = time.time()
     
     if model in ["o1-mini", "o1-preview", "o1", "deepseek-chat", "deepseek-reasoner", "o3-mini"]:
-        # remove system prompt
-        if messages[0].get("role") == "system":
-            sys_msg = messages[0]["content"]
-            messages = messages[1:]
-            messages[0]["content"] = sys_msg + messages[0]["content"]
+        # find any system message, save its value, and remove it from the list of messages
+        sys_msg = None
+        for i in range(len(messages)):
+            if messages[i].get("role") == "system":
+                sys_msg = messages.pop(i)["content"]
+                break
+        
+        # if system message is not None, then prepend it to the first user message
+        if sys_msg:
+            for i in range(len(messages)):
+                if messages[i].get("role") == "user":
+                    messages[i]["content"] = sys_msg + messages[i]["content"]
+                    break
+            
     
     request_params = {
         "messages": messages,

--- a/defog_utils/utils_llm.py
+++ b/defog_utils/utils_llm.py
@@ -277,9 +277,10 @@ async def chat_openai_async(
         if sys_msg:
             for i in range(len(messages)):
                 if messages[i].get("role") == "user":
-                    messages[i]["content"] = sys_msg + messages[i]["content"]
+                    messages[i]["content"] = sys_msg + "\n" + messages[i]["content"]
                     break
-            
+        
+        print(messages)
     
     request_params = {
         "messages": messages,


### PR DESCRIPTION
In OpenAI's new reasoning models, system messages have been disabled, and replaced with another kind of message with the role "developer".

Our previous approach for handling system messages was pretty bad, and it assumed that the system message could only be the first message. This one is a lot more robust.