### PR TITLE
Tool calling for anthropic models

### DIFF
--- a/defog_utils/models.py
+++ b/defog_utils/models.py
@@ -4,10 +4,10 @@ from typing import Optional, Union, Dict, Any
 
 class OpenAIToolChoice(Enum):
     AUTO = "auto" # default if not provided. calls 0, 1, or multiple functions
-    REQUIRED = "required" # calls atleast 1 function
+    REQUIRED = "required" # calls at least 1 function
     NONE = "none" # calls no functions
 
-class OpenAIFunction(BaseModel):
+class OpenAIFunctionSpecs(BaseModel):
     name: str # name of the function to call
     description: Optional[str] = None # description of the function
     parameters: Optional[Union[str, Dict[str, Any]]] = None # parameters of the function
@@ -15,5 +15,18 @@ class OpenAIFunction(BaseModel):
 class OpenAIForcedFunction(BaseModel):
     # a forced function call - forces a call to one specific function
     type: str = "function"
-    function: OpenAIFunction
+    function: OpenAIFunctionSpecs
 
+class AnthropicToolChoice(Enum):
+    AUTO = "auto" # default if not provided. calls 0, 1, or multiple functions
+    REQUIRED = "required" # calls at least 1 function
+
+class AnthropicFunctionSpecs(BaseModel):
+    name: str # name of the function to call
+    description: Optional[str] = None # description of the function
+    input_schema: Optional[Union[str, Dict[str, Any]]] = None # parameters of the function
+
+class AnthropicForcedFunction(BaseModel):
+    # a forced function call - forces a call to one specific function
+    type: str = "function"
+    function: AnthropicFunctionSpecs

--- a/defog_utils/utils_llm.py
+++ b/defog_utils/utils_llm.py
@@ -174,14 +174,9 @@ async def _process_anthropic_response(
                 except KeyError:
                     raise Exception(f"Tool `{func_name}` not found.")
 
-                # check if tool_to_call is async, by seeing if it has `await ` anywhere in its code
-                tool_source = inspect.getsource(tool_to_call)
-                pattern = r"\s+await\s+"
-                matches = re.findall(pattern, tool_source)
-
                 # Execute tool depending on whether it is async
                 try:
-                    if any(match for match in matches):
+                    if inspect.iscoroutinefunction(tool_to_call):
                         result = await execute_tool_async(tool_to_call, args)
                     else:
                         result = execute_tool(tool_to_call, args)
@@ -542,14 +537,9 @@ async def _process_openai_response(
                 except KeyError:
                     raise Exception(f"Tool `{func_name}` not found")
 
-                # check if tool_to_call is async, by seeing if it has `await ` anywhere in its code
-                tool_source = inspect.getsource(tool_to_call)
-                pattern = r"\s+await\s+"
-                matches = re.findall(pattern, tool_source)
-
                 # Execute tool depending on whether it is async
                 try:
-                    if any(match for match in matches):
+                    if inspect.iscoroutinefunction(tool_to_call):
                         result = await execute_tool_async(tool_to_call, args)
                     else:
                         result = execute_tool(tool_to_call, args)

--- a/defog_utils/utils_llm.py
+++ b/defog_utils/utils_llm.py
@@ -76,16 +76,22 @@ class LLMResponse:
 
         if model_name:
             self.cost_in_cents = (
-                self.input_tokens / 1000 * LLM_COSTS_PER_TOKEN[model_name]["input_cost_per1k"]
-                + self.output_tokens / 1000 * LLM_COSTS_PER_TOKEN[model_name]["output_cost_per1k"]
+                self.input_tokens
+                / 1000
+                * LLM_COSTS_PER_TOKEN[model_name]["input_cost_per1k"]
+                + self.output_tokens
+                / 1000
+                * LLM_COSTS_PER_TOKEN[model_name]["output_cost_per1k"]
                 * 100
             )
+
 
 #
 # --------------------------------------------------------------------------------
 # 1) ANTHROPIC
 # --------------------------------------------------------------------------------
 #
+
 
 def _build_anthropic_params(
     messages: List[Dict[str, str]],
@@ -315,6 +321,7 @@ async def chat_anthropic_async(
 # --------------------------------------------------------------------------------
 #
 
+
 def _build_openai_params(
     messages: List[Dict[str, str]],
     model: str,
@@ -368,13 +375,18 @@ def _build_openai_params(
     }
 
     # Tools are only supported for certain models
-    if tools and len(tools) > 0 and model not in [
-        "o1-mini",
-        "o1-preview",
-        "deepseek-chat",
-        "deepseek-reasoner",
-    ]:
-        function_specs = get_function_specs(tools)
+    if (
+        tools
+        and len(tools) > 0
+        and model
+        not in [
+            "o1-mini",
+            "o1-preview",
+            "deepseek-chat",
+            "deepseek-reasoner",
+        ]
+    ):
+        function_specs = get_function_specs(tools, model)
         request_params["tools"] = function_specs
         if tool_choice:
             request_params["tool_choice"] = tool_choice
@@ -444,7 +456,7 @@ def _process_openai_response_sync(
                 # check if tool_to_call is async, by seeing if it has `await ` anywhere in its code
                 tool_source = inspect.getsource(tool_to_call)
                 # Define the regex pattern
-                pattern = r'\s+await\s+'
+                pattern = r"\s+await\s+"
                 matches = re.findall(pattern, tool_source)
                 if any(match for match in matches):
                     result = asyncio.run(execute_tool_async(tool_to_call, args))
@@ -452,10 +464,12 @@ def _process_openai_response_sync(
                     result = execute_tool(tool_to_call, args)
 
                 # Append the tool calls as an assistant response
-                request_params["messages"].append({
-                    "role": "assistant",
-                    "tool_calls": message.tool_calls,
-                })
+                request_params["messages"].append(
+                    {
+                        "role": "assistant",
+                        "tool_calls": message.tool_calls,
+                    }
+                )
 
                 # Append the tool message
                 request_params["messages"].append(
@@ -466,9 +480,7 @@ def _process_openai_response_sync(
                     }
                 )
                 # Make next call
-                response = client.chat.completions.create(
-                    **request_params
-                )
+                response = client.chat.completions.create(**request_params)
             else:
                 content = message.content
                 break
@@ -480,7 +492,13 @@ def _process_openai_response_sync(
             content = response.choices[0].message.content
 
     usage = response.usage
-    return content, usage.prompt_tokens, usage.completion_tokens, usage.completion_tokens_details
+    return (
+        content,
+        usage.prompt_tokens,
+        usage.completion_tokens,
+        usage.completion_tokens_details,
+    )
+
 
 async def _process_openai_response_async(
     client,
@@ -517,11 +535,11 @@ async def _process_openai_response_async(
                     tool_to_call = tool_dict[func_name]
                 except KeyError:
                     raise Exception(f"Tool `{func_name}` not found.")
-                
+
                 # check if tool_to_call is async, by seeing if it has `await ` anywhere in its code
                 tool_source = inspect.getsource(tool_to_call)
                 # Define the regex pattern
-                pattern = r'\s+await\s+'
+                pattern = r"\s+await\s+"
                 matches = re.findall(pattern, tool_source)
                 if any(match for match in matches):
                     result = await execute_tool_async(tool_to_call, args)
@@ -529,10 +547,12 @@ async def _process_openai_response_async(
                     result = execute_tool(tool_to_call, args)
 
                 # Append the tool calls as an assistant response
-                request_params["messages"].append({
-                    "role": "assistant",
-                    "tool_calls": message.tool_calls,
-                })
+                request_params["messages"].append(
+                    {
+                        "role": "assistant",
+                        "tool_calls": message.tool_calls,
+                    }
+                )
 
                 # Append the tool message
                 request_params["messages"].append(
@@ -543,9 +563,7 @@ async def _process_openai_response_async(
                     }
                 )
                 # Make next call
-                response = await client.chat.completions.create(
-                    **request_params
-                )
+                response = await client.chat.completions.create(**request_params)
             else:
                 content = message.content
                 break
@@ -557,8 +575,12 @@ async def _process_openai_response_async(
             content = response.choices[0].message.content
 
     usage = response.usage
-    return content, usage.prompt_tokens, usage.completion_tokens, usage.completion_tokens_details
-
+    return (
+        content,
+        usage.prompt_tokens,
+        usage.completion_tokens,
+        usage.completion_tokens_details,
+    )
 
 
 def chat_openai(
@@ -612,14 +634,16 @@ def chat_openai(
     else:
         response = client_openai.chat.completions.create(**request_params)
 
-    content, prompt_tokens, output_tokens, completion_token_details = _process_openai_response_sync(
-        client=client_openai,
-        response=response,
-        request_params=request_params,
-        tools=tools,
-        tool_dict=tool_dict,
-        response_format=response_format,
-        model=model,
+    content, prompt_tokens, output_tokens, completion_token_details = (
+        _process_openai_response_sync(
+            client=client_openai,
+            response=response,
+            request_params=request_params,
+            tools=tools,
+            tool_dict=tool_dict,
+            response_format=response_format,
+            model=model,
+        )
     )
 
     return LLMResponse(
@@ -676,21 +700,23 @@ async def chat_openai_async(
     tool_dict = {}
     if tools and len(tools) > 0 and "tools" in request_params:
         tool_dict = {tool.__name__: tool for tool in tools}
-    
+
     # If response_format is set, we do parse
     if request_params.get("response_format"):
         response = await client_openai.beta.chat.completions.parse(**request_params)
     else:
         response = await client_openai.chat.completions.create(**request_params)
 
-    content, prompt_tokens, output_tokens, completion_token_details = await _process_openai_response_async(
-        client=client_openai,
-        response=response,
-        request_params=request_params,
-        tools=tools,
-        tool_dict=tool_dict,
-        response_format=response_format,
-        model=model
+    content, prompt_tokens, output_tokens, completion_token_details = (
+        await _process_openai_response_async(
+            client=client_openai,
+            response=response,
+            request_params=request_params,
+            tools=tools,
+            tool_dict=tool_dict,
+            response_format=response_format,
+            model=model,
+        )
     )
 
     return LLMResponse(
@@ -702,11 +728,13 @@ async def chat_openai_async(
         output_tokens_details=completion_token_details,
     )
 
+
 #
 # --------------------------------------------------------------------------------
 # 3) TOGETHER
 # --------------------------------------------------------------------------------
 #
+
 
 def _build_together_params(
     messages: List[Dict[str, str]],
@@ -814,11 +842,13 @@ async def chat_together_async(
         output_tokens=output_toks,
     )
 
+
 #
 # --------------------------------------------------------------------------------
 # 4) GEMINI
 # --------------------------------------------------------------------------------
 #
+
 
 def _build_gemini_params(
     messages: List[Dict[str, str]],
@@ -898,11 +928,17 @@ def chat_gemini(
     )
 
     try:
-        response = client.models.generate_content(model=model, contents=message, config=types.GenerateContentConfig(**generation_cfg))
+        response = client.models.generate_content(
+            model=model,
+            contents=message,
+            config=types.GenerateContentConfig(**generation_cfg),
+        )
     except Exception as e:
         raise Exception(f"An error occurred: {e}")
 
-    content, input_toks, output_toks = _process_gemini_response(response, response_format)
+    content, input_toks, output_toks = _process_gemini_response(
+        response, response_format
+    )
     return LLMResponse(
         model=model,
         content=content,
@@ -955,7 +991,9 @@ async def chat_gemini_async(
     except Exception as e:
         raise Exception(f"An error occurred: {e}")
 
-    content, input_toks, output_toks = _process_gemini_response(response, response_format)
+    content, input_toks, output_toks = _process_gemini_response(
+        response, response_format
+    )
     return LLMResponse(
         model=model,
         content=content,

--- a/defog_utils/utils_llm.py
+++ b/defog_utils/utils_llm.py
@@ -83,8 +83,7 @@ class LLMResponse:
                 + self.output_tokens
                 / 1000
                 * LLM_COSTS_PER_TOKEN[model_name]["output_cost_per1k"]
-                * 100
-            )
+            ) * 100
 
 
 #

--- a/defog_utils/utils_llm.py
+++ b/defog_utils/utils_llm.py
@@ -664,7 +664,14 @@ def chat_together(
 
     t = time.time()
     client_together = Together()
-    params = _build_together_params(messages, model, max_completion_tokens, temperature, stop, seed)
+    params = _build_together_params(
+        messages=messages,
+        model=model,
+        max_completion_tokens=max_completion_tokens,
+        temperature=temperature,
+        stop=stop,
+        seed=seed,
+    )
     response = client_together.chat.completions.create(**params)
 
     content, input_toks, output_toks = _process_together_response(response)
@@ -698,7 +705,14 @@ async def chat_together_async(
 
     t = time.time()
     client_together = AsyncTogether(timeout=timeout)
-    params = _build_together_params(messages, model, max_completion_tokens, temperature, stop, seed)
+    params = _build_together_params(
+        messages=messages,
+        model=model,
+        max_completion_tokens=max_completion_tokens,
+        temperature=temperature,
+        stop=stop,
+        seed=seed,
+    )
     response = await client_together.chat.completions.create(**params)
 
     content, input_toks, output_toks = _process_together_response(response)
@@ -782,7 +796,15 @@ def chat_gemini(
     t = time.time()
     client = genai.Client(api_key=os.getenv("GEMINI_API_KEY", ""))
     message, generation_cfg = _build_gemini_params(
-        messages, model, max_completion_tokens, temperature, stop, response_format, seed, store, metadata
+        messages=messages,
+        model=model,
+        max_completion_tokens=max_completion_tokens,
+        temperature=temperature,
+        stop=stop,
+        response_format=response_format,
+        seed=seed,
+        store=store,
+        metadata=metadata,
     )
 
     try:
@@ -823,7 +845,15 @@ async def chat_gemini_async(
     t = time.time()
     client = genai.Client(api_key=os.getenv("GEMINI_API_KEY", ""))
     message, generation_cfg = _build_gemini_params(
-        messages, model, max_completion_tokens, temperature, stop, response_format, seed, store, metadata
+        messages=messages,
+        model=model,
+        max_completion_tokens=max_completion_tokens,
+        temperature=temperature,
+        stop=stop,
+        response_format=response_format,
+        seed=seed,
+        store=store,
+        metadata=metadata,
     )
 
     try:

--- a/defog_utils/utils_llm.py
+++ b/defog_utils/utils_llm.py
@@ -384,13 +384,15 @@ async def chat_anthropic_async(
         tool_dict = {tool.__name__: tool for tool in tools}
 
     response = await client.messages.create(**params)
-    content, tools_used, input_toks, output_toks = await _process_anthropic_response_handler(
-        client=client,
-        response=response,
-        request_params=params,
-        tools=tools,
-        tool_dict=tool_dict,
-        is_async=True,
+    content, tools_used, input_toks, output_toks = (
+        await _process_anthropic_response_handler(
+            client=client,
+            response=response,
+            request_params=params,
+            tools=tools,
+            tool_dict=tool_dict,
+            is_async=True,
+        )
     )
 
     return LLMResponse(
@@ -605,7 +607,7 @@ def _process_openai_response_handler(
 ):
     """
     Processes OpenAI's response by determining whether to execute the response handling
-    synchronously or asynchronously. This function acts as a wrapper around _process_openai_response, 
+    synchronously or asynchronously. This function acts as a wrapper around _process_openai_response,
     deciding the execution mode based on the is_async parameter.
 
     Parameters:

--- a/defog_utils/utils_llm.py
+++ b/defog_utils/utils_llm.py
@@ -264,23 +264,6 @@ def _process_anthropic_response_handler(
                 tool_dict=tool_dict,
                 is_async=is_async,
             )  # Caller must await this
-
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-
-        if loop and loop.is_running():
-            return asyncio.ensure_future(
-                _process_anthropic_response(
-                    client=client,
-                    response=response,
-                    request_params=request_params,
-                    tools=tools,
-                    tool_dict=tool_dict,
-                    is_async=is_async,
-                )
-            )  # Returns a future
         else:
             return asyncio.run(
                 _process_anthropic_response(
@@ -633,25 +616,6 @@ def _process_openai_response_handler(
                 model=model,
                 is_async=is_async,
             )  # Caller must await this
-
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-
-        if loop and loop.is_running():
-            return asyncio.ensure_future(
-                _process_openai_response(
-                    client=client,
-                    response=response,
-                    request_params=request_params,
-                    tools=tools,
-                    tool_dict=tool_dict,
-                    response_format=response_format,
-                    model=model,
-                    is_async=is_async,
-                )
-            )  # Returns a future
         else:
             return asyncio.run(
                 _process_openai_response(

--- a/tests/test_utils_tool_use.py
+++ b/tests/test_utils_tool_use.py
@@ -17,28 +17,31 @@ if DEFOG_API_KEY is None:
 # Functions for function calling
 # ==================================================================================================
 
+
 def clean_html_text(html_text):
     """
     Remove HTML tags from the given HTML text and return plain text.
-    
+
     Args:
         html_text (str): A string containing HTML content.
-    
+
     Returns:
         str: A string with the HTML tags removed.
     """
     # Parse the HTML content
     soup = BeautifulSoup(html_text, "html.parser")
-    
+
     # Extract text from the parsed HTML
     # The separator parameter defines what string to insert between text blocks.
     # strip=True removes leading and trailing whitespace from each piece of text.
     cleaned_text = soup.get_text(separator=" ", strip=True)
-    
+
     return cleaned_text
+
 
 class SearchInput(BaseModel):
     query: str = ""
+
 
 async def search(input: SearchInput):
     """
@@ -53,9 +56,11 @@ async def search(input: SearchInput):
         r = await client.get(first_result_link)
     return clean_html_text(r.text)
 
+
 class Numbers(BaseModel):
-            a: int = 0
-            b: int = 0
+    a: int = 0
+    b: int = 0
+
 
 def numsum(input: Numbers):
     """
@@ -63,11 +68,13 @@ def numsum(input: Numbers):
     """
     return input.a + input.b
 
+
 def numprod(input: Numbers):
     """
     This function return the product of two numbers
     """
     return input.a * input.b
+
 
 # ==================================================================================================
 # Tests
@@ -80,7 +87,7 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
         self.search_answer = "lawrence wong"
 
         self.arithmetic_qn = "What is the product of 31283 and 2323, added to 5? Return only the final answer, nothing else."
-        self.arithmetic_answer = '72670414'
+        self.arithmetic_answer = "72670414"
 
     @pytest.mark.asyncio
     async def test_tool_use_arithmetic_async_openai(self):
@@ -91,7 +98,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             messages=[
                 {
                     "role": "user",
-                    "content": self.arithmetic_qn,},
+                    "content": self.arithmetic_qn,
+                },
             ],
             tools=tools,
         )
@@ -105,13 +113,13 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             messages=[
                 {
                     "role": "user",
-                    "content": self.search_qn,},
+                    "content": self.search_qn,
+                },
             ],
             tools=tools,
             max_retries=1,
         )
         self.assertIn(self.search_answer, result.content.lower())
-    
 
     def test_async_tool_in_sync_function_openai(self):
         tools = self.tools

--- a/tests/test_utils_tool_use.py
+++ b/tests/test_utils_tool_use.py
@@ -3,7 +3,7 @@ import pytest
 from ..defog_utils.utils_multi_llm import chat_async, chat
 from ..defog_utils.utils_llm import chat_anthropic, chat_openai
 from ..defog_utils.utils_function_calling import get_function_specs
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 import httpx
 import os
 
@@ -41,7 +41,7 @@ def clean_html_text(html_text):
 
 
 class SearchInput(BaseModel):
-    query: str = ""
+    query: str = Field(default="", description="The query to search for")
 
 
 async def search(input: SearchInput):
@@ -94,7 +94,7 @@ class TestGetFunctionSpecs(unittest.TestCase):
                     "description": "This function searches Google for the given query. It then visits the first result page, and returns the HTML content of the page.",
                     "parameters": {
                         "properties": {
-                            "query": {"default": "", "title": "Query", "type": "string"}
+                            "query": {"default": "", "description": "The query to search for", "title": "Query", "type": "string"}
                         },
                         "title": "SearchInput",
                         "type": "object",
@@ -138,7 +138,7 @@ class TestGetFunctionSpecs(unittest.TestCase):
                 "description": "This function searches Google for the given query. It then visits the first result page, and returns the HTML content of the page.",
                 "input_schema": {
                     "properties": {
-                        "query": {"default": "", "title": "Query", "type": "string"}
+                        "query": {"default": "", "description": "The query to search for", "title": "Query", "type": "string"}
                     },
                     "title": "SearchInput",
                     "type": "object",

--- a/tests/test_utils_tool_use.py
+++ b/tests/test_utils_tool_use.py
@@ -104,6 +104,7 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             tools=tools,
         )
         self.assertEqual(result.content, self.arithmetic_answer)
+        self.assertSetEqual(set(result.tools_used), {"numsum", "numprod"})
 
     @pytest.mark.asyncio
     async def test_tool_use_search_async_openai(self):
@@ -120,6 +121,41 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             max_retries=1,
         )
         self.assertIn(self.search_answer, result.content.lower())
+        self.assertSetEqual(set(result.tools_used), {"search"})
+
+    @pytest.mark.asyncio
+    async def test_tool_use_arithmetic_async_anthropic(self):
+        tools = self.tools
+
+        result = await chat_async(
+            model="claude-3-haiku-20240307",
+            messages=[
+                {
+                    "role": "user",
+                    "content": self.arithmetic_qn,
+                },
+            ],
+            tools=tools,
+        )
+        self.assertEqual(result.content, self.arithmetic_answer)
+        self.assertSetEqual(set(result.tools_used), {"numsum", "numprod"})
+
+    @pytest.mark.asyncio
+    async def test_tool_use_search_async_anthropic(self):
+        tools = self.tools
+        result = await chat_async(
+            model="claude-3-haiku-20240307",
+            messages=[
+                {
+                    "role": "user",
+                    "content": self.search_qn,
+                },
+            ],
+            tools=tools,
+            max_retries=1,
+        )
+        self.assertIn(self.search_answer, result.content.lower())
+        self.assertSetEqual(set(result.tools_used), {"search"})
 
     def test_async_tool_in_sync_function_openai(self):
         tools = self.tools
@@ -134,6 +170,7 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             tools=tools,
         )
         self.assertIn(self.search_answer, result_openai.content.lower())
+        self.assertSetEqual(set(result_openai.tools_used), {"search"})
 
     def test_async_tool_in_sync_function_anthropic(self):
         tools = self.tools
@@ -148,3 +185,4 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             tools=tools,
         )
         self.assertIn(self.search_answer, result_anthropic.content.lower())
+        self.assertSetEqual(set(result_anthropic.tools_used), {"search"})


### PR DESCRIPTION
With this PR, we can now perform tool calls using Anthropic models. Functions are converted to their specs based on Anthropic's [tool schema definition](https://docs.anthropic.com/en/docs/build-with-claude/tool-use#specifying-tools).

Note that to give LLMs extra context on the different function parameters (in addition to the types and function description from the docstring), we can add param `description` fields in the Pydantic classes as follows:
```
class Numbers(BaseModel):
    a: int = Field(0, description="The first integer value, defaults to 0.")
    b: int = Field(0, description="The second integer value, defaults to 0.")


def numsum(input: Numbers):
    """
    This function returns the sum of two numbers
    """
    return input.a + input.b
```

## Refactoring
- `_process_openai_response_handler` has been added as a wrapper for `_process_openai_response`, further avoiding code duplication between sync and async methods for easier maintenance. 
- Instead of searching for `await` regex pattern in functions, we now use `inspect.iscoroutinefunction` to accurately determine if a function is a coroutine and requires async tool execution.

## More tests
- New tests have been added for testing anthropic chat functions. The tests now also explicitly check for the correct `tools_used` in addition to checks for the response output. 
- `test_get_function_specs` is added to ensure that the functions are converted to the right schemas depending on the model selected.

## Other minor changes
- Pydantic classes have been renamed slightly for clarity
- A bug in LLM cost calculation has been fixed
- Positional arguments have been replaced with keyword arguments to prevent errors